### PR TITLE
docs: fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   </a>
 </p>
 
-This is a repository of pretrained Japapanese transformer-based models.
+This is a repository of pretrained Japanese transformer-based models.
 BERT, ELECTRA, RoBERTa, DeBERTa, and DeBERTaV2 is available.
 
 Our pre-trained models are available in Transformers by Hugging Face: [https://huggingface.co/izumi-lab](https://huggingface.co/izumi-lab).
@@ -100,7 +100,7 @@ The output directory name is `<dataset_type>_<max_length>_<input_corpus>`.
 In the following case, the output directory name is `nsp_128_wiki-ja`.  
 ``tokenizer_name_or_path`` will end with vocab.txt for wordpiece and with spiece.model for sentencepiece.
 
-We show 3 examples to create dataset.
+We show 2 examples to create dataset.
 
 - When you use your trained tokenizer:
 


### PR DESCRIPTION
This PR fixes two typos in README.md. Thank you for publishing useful code. The number of examples should be fix at commit c390a511eeabe670e1ecff932b05407629644a49.

If this repo doesn't accept other's commit, I don't mind if this PR is closed.